### PR TITLE
Fix string enum types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -154,5 +154,15 @@ events.forEach((event: Event): void => {
     case EventsPhase.LINKED_ID_EVENTS:
       handleLinkedIDEvent(event);
       break;
+    default: {
+      // This case should only be hit if we've forgotten to handle
+      // a type of event, or if the incoming data does not match any
+      // of the expected phases at runtime
+      throw new Error(
+        `Unknown event type "${
+          (event as any).ph
+        }" in trace event ${JSON.stringify(event)}`
+      );
+    }
   }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,67 +92,67 @@ const handleLinkedIDEvent = (event: LinkedIDEvent): LinkedIDEvent => {
 events.forEach((event: Event): void => {
   switch (event.ph) {
     case EventsPhase.METADATA_EVENTS:
-      handleMetadataEvent(event as MetadataEvent);
+      handleMetadataEvent(event);
       break;
 
     case EventsPhase.DURATION_EVENTS_BEGIN:
     case EventsPhase.DURATION_EVENTS_END:
-      handleDurationEvent(event as DurationEvent);
+      handleDurationEvent(event);
       break;
 
     case EventsPhase.COMPLETE_EVENTS:
-      handleCompleteEvent(event as CompleteEvent);
+      handleCompleteEvent(event);
       break;
 
     case EventsPhase.SAMPLE_EVENTS:
-      handleSampleEvent(event as SampleEvent);
+      handleSampleEvent(event);
       break;
 
     case EventsPhase.OBJECT_EVENTS_CREATED:
     case EventsPhase.OBJECT_EVENTS_SNAPSHOT:
     case EventsPhase.OBJECT_EVENTS_DESTROYED:
-      handleObjectEvent(event as ObjectEvent);
+      handleObjectEvent(event);
       break;
 
     case EventsPhase.CLOCK_SYNC_EVENTS:
-      handleClockSyncEvent(event as ClockSyncEvent);
+      handleClockSyncEvent(event);
       break;
 
     case EventsPhase.ASYNC_EVENTS_NESTABLE_START:
     case EventsPhase.ASYNC_EVENTS_NESTABLE_INSTANT:
     case EventsPhase.ASYNC_EVENTS_NESTABLE_END:
-      handleAsyncEvent(event as AsyncEvent);
+      handleAsyncEvent(event);
       break;
 
     case EventsPhase.CONTEXT_EVENTS_ENTER:
     case EventsPhase.CONTEXT_EVENTS_LEAVE:
-      handleContextEvent(event as ContextEvent);
+      handleContextEvent(event);
       break;
     case EventsPhase.INSTANT_EVENTS:
-      handleInstantEvent(event as InstantEvent);
+      handleInstantEvent(event);
       break;
 
     case EventsPhase.COUNTER_EVENTS:
-      handleCounterEvent(event as CounterEvent);
+      handleCounterEvent(event);
       break;
 
     case EventsPhase.FLOW_EVENTS_START:
     case EventsPhase.FLOW_EVENTS_STEP:
     case EventsPhase.FLOW_EVENTS_END:
-      handleFlowEvent(event as FlowEvent);
+      handleFlowEvent(event);
       break;
 
     case EventsPhase.MEMORY_DUMP_EVENTS_GLOBAL:
     case EventsPhase.MEMORY_DUMP_EVENTS_PROCESS:
-      handleMemoryDumpEvent(event as MemoryDumpEvent);
+      handleMemoryDumpEvent(event);
       break;
 
     case EventsPhase.MARK_EVENTS:
-      handleMarkEvent(event as MarkEvent);
+      handleMarkEvent(event);
       break;
 
     case EventsPhase.LINKED_ID_EVENTS:
-      handleLinkedIDEvent(event as LinkedIDEvent);
+      handleLinkedIDEvent(event);
       break;
   }
 });

--- a/src/types/__tests__/EventInterfaces.ts
+++ b/src/types/__tests__/EventInterfaces.ts
@@ -90,4 +90,42 @@ describe('Event', () => {
       { ts: 'ts', ph: 'invalid' },
     ]);
   });
+
+  it('should support type guards', () => {
+    // If we want to ensure that a type is *actually* of the type
+    // we want it to be instead of relying on type coercion/casting,
+    // we can use a type guard
+    //
+    // See: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
+    function isFlowEvent(event: any): event is FlowEvent {
+      return (
+        event.ph === EventsPhase.FLOW_EVENTS_START ||
+        event.ph === EventsPhase.FLOW_EVENTS_END ||
+        event.ph === EventsPhase.FLOW_EVENTS_STEP
+      );
+    }
+
+    // This function expects a flow event
+    function expectsFlowEvent(event: FlowEvent): any {
+      return event.ph;
+    }
+
+    // This
+    const flowEventLike = { ts: 'ts', ph: 's' };
+
+    // This fails, because string `s` is not coerced to EventsPhase
+    // @ts-expect-error
+    expectsFlowEvent(flowEventLike);
+
+    // But if we use our type guard first...
+    if (isFlowEvent(flowEventLike)) {
+      // This will pass, because isFlowEvent type guard refines the type
+      // by checking that the value matches the expected type
+      expectsFlowEvent(flowEventLike);
+    } else {
+      // This will fail, because the value didn't match
+      // @ts-expect-error
+      expectsFlowEvent(flowEventLike);
+    }
+  });
 });

--- a/src/types/__tests__/EventInterfaces.ts
+++ b/src/types/__tests__/EventInterfaces.ts
@@ -1,0 +1,93 @@
+import { Event, FlowEvent, DurationEvent } from '../EventInterfaces';
+import { EventsPhase } from '../Phases';
+
+/**
+ * These tests are 50% about testing that the types are implemented correctly,
+ * and 50% documenting how to handle mapping between Event types and subtypes
+ * with and without EventsPhas literal.
+ *
+ * The tests rely on the @ts-expect-error pragma, which will pass the type check
+ * if the following line has a type error, and will error if the following line is fine.
+ */
+describe('Event', () => {
+  it('should allow constructing event objects using EventsPhase enum values', () => {
+    // create a new flow event
+    const event: FlowEvent = {
+      ts: 'ts',
+      ph: EventsPhase.FLOW_EVENTS_START,
+    };
+
+    // check that value is correct in runtime
+    expect(event).toEqual({ ts: 'ts', ph: 's' });
+  });
+  it('should not allow constructing event objects using wrong enum values', () => {
+    // try to create a new flow event, should fail with TypeScript error
+    // @ts-expect-error
+    const event: FlowEvent = { ts: 'ts', ph: EventsPhase.INSTANT_EVENTS };
+
+    // at runtime object is still created, but we should never be here
+    expect(event).toEqual({ ts: 'ts', ph: 'I' });
+  });
+
+  it('should not allow constructing event objects with phase literal at type level', () => {
+    // try to create a new flow event, should fail with TypeScript error
+    // @ts-expect-error
+    const event: FlowEvent = { ts: 'ts', ph: 's' };
+
+    // check that value is correct in runtime
+    expect(event).toEqual({ ts: 'ts', ph: 's' });
+  });
+
+  it('should allow coercing event objects with correct phase literal', () => {
+    const event: FlowEvent = { ts: 'ts', ph: 's' } as FlowEvent;
+
+    // check that value is correct in runtime
+    expect(event).toEqual({ ts: 'ts', ph: 's' });
+  });
+
+  it('should not allow coercing event objects with incorrect phase literal', () => {
+    // try to create a new flow event, should fail with TypeScript error
+    // @ts-expect-error
+    const event: FlowEvent = { ts: 'ts', ph: 'NOT_s' } as FlowEvent;
+
+    // check that value is correct in runtime
+    expect(event).toEqual({ ts: 'ts', ph: 'NOT_s' });
+  });
+
+  it('should allow polymorphic lists of different event types', () => {
+    const flow: FlowEvent = { ts: 'ts', ph: EventsPhase.FLOW_EVENTS_STEP };
+    const duration: DurationEvent = {
+      ts: 'ts',
+      ph: EventsPhase.DURATION_EVENTS_BEGIN,
+    };
+
+    // should not type error
+    const events: Event[] = [flow, duration];
+
+    expect(events).toEqual([
+      { ts: 'ts', ph: 't' },
+      { ts: 'ts', ph: 'B' },
+    ]);
+  });
+
+  it('should not allow polymorphic lists where any value is not a valid event type', () => {
+    const flow: FlowEvent = { ts: 'ts', ph: EventsPhase.FLOW_EVENTS_STEP };
+    const duration: DurationEvent = {
+      ts: 'ts',
+      ph: EventsPhase.DURATION_EVENTS_BEGIN,
+    };
+    const invalid = {
+      ts: 'ts',
+      ph: 'invalid',
+    };
+
+    // @ts-expect-error
+    const events: Event[] = [flow, duration, invalid];
+
+    expect(events).toEqual([
+      { ts: 'ts', ph: 't' },
+      { ts: 'ts', ph: 'B' },
+      { ts: 'ts', ph: 'invalid' },
+    ]);
+  });
+});

--- a/src/types/__tests__/Phases.test.ts
+++ b/src/types/__tests__/Phases.test.ts
@@ -1,0 +1,18 @@
+import { EventsPhase } from '../Phases';
+
+describe('EventPhase', () => {
+  it('should map to corresponding string value correctly at type-level and runtime', () => {
+    // If you added @ts-expect-error below, the type check should
+    // error because the comparison always returns false
+
+    expect(EventsPhase.DURATION_EVENTS_BEGIN === 'B').toBe(true);
+  });
+
+  it('should cause a type error and fail runtime check when compared to incorrect literal', () => {
+    // If you remove @ts-expect-error below, the type check should
+    // error because the comparison always returns false
+
+    // @ts-expect-error
+    expect(EventsPhase.DURATION_EVENTS_BEGIN === 'NOT_B').toBe(false);
+  });
+});


### PR DESCRIPTION

## The Problem

After creating a [beautiful type abstraction](https://github.com/MLH-Fellowship/hermes-profile-transformer/blob/master/src/types/EventInterfaces.ts) that [allowed us to discriminate/narrow types by their `ph` phase values](https://github.com/MLH-Fellowship/hermes-profile-transformer/blob/master/src/index.ts#L93-L157), we discovered a problem: Untyped data that we ingested into the system wasn't compatible with the types we defined! 😨 

![image](https://user-images.githubusercontent.com/1203949/85051336-49834200-b18f-11ea-9beb-880c08d07b11.png)

This turned out to be because [TypeScript does not implement reverse mapping for String-valued Enum type members](https://mariusschulz.com/blog/string-enums-in-typescript#no-reverse-mapping-for-string-valued-enum-members). 

## The "Fix"

I did a bit of research on this, and the best solution to the problem is to do... nothing 😄 

[The first commit](https://github.com/MLH-Fellowship/hermes-profile-transformer/commit/488ad789e788029b77972aaef43dec07eba32ca9) removes the `as {X}Event` casts. 

We had added these to get rid of type errors, but turns out that as soon as we added the `as Event[]` cast at [index.ts:20](https://github.com/MLH-Fellowship/hermes-profile-transformer/blob/fix/enum-types/src/index.ts#L20), these had become redundant, because the TypeScript compiler was able to correctly narrow down the types based on enum values once we had given it the hint that all the events are in fact of type `Event`.

## The Safety

The solution is to assume (on type level) that the incoming data are all valid `Event` subtypes. 

However, if that is not the case, we'll [catch them in the `default` case and throw a runtime error](https://github.com/MLH-Fellowship/hermes-profile-transformer/commit/45e66bd219af03be17a0b4e165b4f7ab78346999).

This is good, because as we develop, we'll want to know if we have forgotten or neglected to handle an event phase, and this will make it clear. Similarly, if in the future a user will upload a profile that contains an event type we weren't aware of, this will give a clear error message instead of lead to a subtle bug or an unexpected crash.

## How to deal with enum literals inside the program

So, once we've ingested all the data into the app, we should be safe in assuming that all event objects have correct phases, and therefore have the correct type information attached to them. However, there may be cases where we'll need to construct new event objects, or manipulate them in other ways.

The [second commit](https://github.com/MLH-Fellowship/hermes-profile-transformer/commit/ef76fdb89a37b863315df540fc717c4cd2424e19) adds a bunch of tests that show both succeeding and failing approaches. These tests may not be very useful in catching bugs, but we can leave them as documentation on how to use the TypeScript types for Events and EventsPhases.

These tests rely heavily on [`@ts-expect-error` annotations](https://devblogs.microsoft.com/typescript/announcing-typescript-3-9-beta/#ts-expect-error-comments), which allow us to test whether our types are correct or not.

In order to get a feel how the different cases work, I recommend checking this branch out and playing with them in your TypeScript IDE (VSCode etc).

## Further refinement

Finally, if we don't want to make any assumptions about the input types, we can use [User-Defined Type Guards](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) to refine types based on their values. The [third commit](https://github.com/MLH-Fellowship/hermes-profile-transformer/commit/3c7e35d46a98bdb81c7b6a44e819f0e03f343d42) adds a test that shows how this can be done. 

This, however, should not be necessary, since once the data is ingested, all the types should be inferred correctly.