### PR TITLE
Support older versions of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=8"
   },
   "scripts": {
     "start": "tsdx watch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { CpuProfilerModel } from './profiler/cpuProfilerModel';
 import { DurationEvent } from './types/EventInterfaces';
-import { readFile } from './utils/fileSystem';
+import { readFileAsync } from './utils/fileSystem';
 import { HermesCPUProfile } from './types/HermesProfile';
 import applySourceMapsToEvents from './profiler/applySourceMapsToEvents';
 import { SourceMap } from './types/SourceMap';
@@ -18,12 +18,12 @@ const transformer = async (
   sourceMapPath: string | undefined,
   bundleFileName: string | undefined
 ): Promise<DurationEvent[]> => {
-  const hermesProfile: HermesCPUProfile = await readFile(profilePath);
+  const hermesProfile: HermesCPUProfile = await readFileAsync(profilePath);
   const profileChunk = CpuProfilerModel.collectProfileEvents(hermesProfile);
   const profiler = new CpuProfilerModel(profileChunk);
   const chromeEvents = profiler.createStartEndEvents();
   if (sourceMapPath) {
-    const sourceMap: SourceMap = await readFile(sourceMapPath);
+    const sourceMap: SourceMap = await readFileAsync(sourceMapPath);
     const events = applySourceMapsToEvents(
       sourceMap,
       chromeEvents,

--- a/src/utils/fileSystem.ts
+++ b/src/utils/fileSystem.ts
@@ -1,8 +1,10 @@
-import { promises } from 'fs';
+import { readFile } from 'fs';
+import { promisify } from 'util';
 
-export const readFile = async (path: string): Promise<any> => {
+export const readFileAsync = async (path: string): Promise<any> => {
   try {
-    const fileString: string = await promises.readFile(path, 'utf-8');
+    const readFileAsync = promisify(readFile);
+    const fileString: string = (await readFileAsync(path, 'utf-8')) as string;
     if (fileString.length === 0) {
       throw new Error(`${path} is an empty file`);
     }


### PR DESCRIPTION
# Summary

Solves #24 
We needed to downgrade the minimum version of node to allow smooth merging into React Native

To do so, we needed to change the `readFIle` function in [utils/fileSystem](https://github.com/MLH-Fellowship/hermes-profile-transformer/blob/master/src/utils/fileSystem.ts). 

Using `utils.promisify` in addition to the native `fs.readFile` which takes a callback allowed us to do this with ease! 🥳 

# Testing plan

 - Used [`nvm`](https://github.com/nvm-sh/nvm) to switch to an older version of node. The package still runs as expected