### PR TITLE
Fix one off error

### DIFF
--- a/src/profiler/cpuProfilerModel.ts
+++ b/src/profiler/cpuProfilerModel.ts
@@ -247,7 +247,7 @@ export class CpuProfilerModel {
    * @return {CPUProfileChunk}
    */
   static collectProfileEvents(profile: HermesCPUProfile): CPUProfileChunk {
-    if (profile.samples.length >= 0) {
+    if (profile.samples.length > 0) {
       const { samples, stackFrames } = profile;
       // Assumption: The sample will have a single process
       const pid: number = samples[0].pid;


### PR DESCRIPTION
Error "The hermes profile has zero samples" is intended to be thrown but is not thrown because `>= 0` instead of `> 0`