### PR TITLE
fix(readme): Fix `sourceMapPath` const name passed to transformer functon

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ transformer(
   // profile path is required
   hermesCpuProfilePath,
   // source maps are optional
-  sourceMap,
+  sourceMapPath,
   sourceMapBundleFileName
 )
   .then(events => {


### PR DESCRIPTION
I've just noticed a small typo in the example code in the `README.md`.