### PR TITLE
Support for production profiles

### DIFF
--- a/src/__test__/__snapshots__/applySourceMapsToEvents.test.ts.snap
+++ b/src/__test__/__snapshots__/applySourceMapsToEvents.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`applySourceMapsToEvents dev profiles should throw an error if args are not populated 1`] = `"Source maps could not be derived for an event at 1000 and with stackFrame ID undefined"`;

--- a/src/__test__/applySourceMapsToEvents.test.ts
+++ b/src/__test__/applySourceMapsToEvents.test.ts
@@ -1,0 +1,265 @@
+import { SourceMap } from '../types/SourceMap';
+import { SourceMapConsumer } from 'source-map';
+import { DurationEvent } from '../types/EventInterfaces';
+import { EventsPhase } from '../types/Phases';
+import applySourceMapsToEvents from '../profiler/applySourceMapsToEvents';
+
+const mockOriginalPositionFor = jest.fn();
+
+jest.mock('source-map', () => ({
+  SourceMapConsumer: jest.fn().mockImplementation(() => ({
+    originalPositionFor: mockOriginalPositionFor.mockReturnValue({
+      source: 'source.js',
+      line: 1,
+      column: 10,
+      name: 'console.log',
+    }),
+    destroy: jest.fn(),
+  })),
+}));
+
+describe('applySourceMapsToEvents', () => {
+  let defaultEvents: DurationEvent[] = [];
+
+  const mockSourceMap: SourceMap = {
+    version: '3',
+    sources: ['source.js'],
+    sourceContent: ['console.log("Hello, World!");'],
+    x_facebook_sources: null,
+    names: ['console', 'log', 'Hello, World!'],
+    mappings: 'AAAAA,QAAAC,IAAA',
+  };
+
+  beforeEach(() => {
+    ((SourceMapConsumer as unknown) as jest.Mock).mockImplementation(() => ({
+      originalPositionFor: mockOriginalPositionFor.mockReturnValue({
+        source: 'source.js',
+        line: 5,
+        column: 10,
+        name: 'console.log',
+      }),
+      destroy: jest.fn(),
+    }));
+    mockOriginalPositionFor.mockClear();
+
+    // applySourceMapsToEvents modifies the events array, so we need to reset it before each test
+    defaultEvents = [
+      {
+        ph: EventsPhase.DURATION_EVENTS_BEGIN,
+        args: {
+          line: 1,
+          column: 1,
+        },
+        cat: 'default-category',
+        name: 'event1',
+        ts: 1000,
+        pid: 1,
+        tid: 1,
+      },
+      {
+        ph: EventsPhase.DURATION_EVENTS_END,
+        args: {
+          line: 1,
+          column: 1,
+        },
+        cat: 'default-category',
+        name: 'event1',
+        ts: 1010,
+        pid: 1,
+        tid: 1,
+      },
+    ];
+  });
+
+  describe('dev profiles', () => {
+    it('should enhance events with source map information', async () => {
+      const indexBundleFileName = 'index.bundle';
+      const enhancedEvents = await applySourceMapsToEvents(
+        mockSourceMap,
+        defaultEvents,
+        indexBundleFileName
+      );
+
+      expect(enhancedEvents).toEqual([
+        expect.objectContaining({
+          args: {
+            url: 'source.js',
+            line: 5,
+            column: 10,
+            params: 'console.log',
+            allocatedCategory: 'default-category',
+            allocatedName: 'event1',
+            node_module: 'default-category',
+          },
+        }),
+        expect.objectContaining({
+          args: {
+            url: 'source.js',
+            line: 5,
+            column: 10,
+            params: 'console.log',
+            allocatedCategory: 'default-category',
+            allocatedName: 'event1',
+            node_module: 'default-category',
+          },
+        }),
+      ]);
+    });
+
+    it('should throw an error if args are not populated', async () => {
+      const eventsWithMissingArgs: DurationEvent[] = [
+        {
+          ...defaultEvents[0],
+          args: undefined as any,
+        },
+      ];
+
+      await expect(
+        applySourceMapsToEvents(mockSourceMap, eventsWithMissingArgs, undefined)
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('production profiles', () => {
+    it('should enhance events with source map information', async () => {
+      const productionEvents: DurationEvent[] = [
+        {
+          ph: EventsPhase.DURATION_EVENTS_BEGIN,
+          args: {
+            funcVirtAddr: '5',
+            offset: '7',
+          },
+          cat: 'default-category',
+          name: 'event1',
+          ts: 1000,
+          pid: 1,
+          tid: 1,
+        },
+        {
+          ph: EventsPhase.DURATION_EVENTS_END,
+          args: {
+            funcVirtAddr: '5',
+            offset: '7',
+          },
+          cat: 'default-category',
+          name: 'event1',
+          ts: 1010,
+          pid: 1,
+          tid: 1,
+        },
+      ];
+
+      const indexBundleFileName = 'index.bundle';
+      const enhancedEvents = await applySourceMapsToEvents(
+        mockSourceMap,
+        productionEvents,
+        indexBundleFileName
+      );
+
+      expect(mockOriginalPositionFor).toHaveBeenCalledTimes(2);
+      expect(mockOriginalPositionFor).toHaveBeenCalledWith({
+        line: 1,
+        column: 13,
+      });
+
+      expect(enhancedEvents).toEqual([
+        expect.objectContaining({
+          args: {
+            url: 'source.js',
+            line: 5,
+            column: 10,
+            funcVirtAddr: '5',
+            offset: '7',
+            params: 'console.log',
+            allocatedCategory: 'default-category',
+            allocatedName: 'event1',
+            node_module: 'default-category',
+          },
+        }),
+        expect.objectContaining({
+          args: {
+            url: 'source.js',
+            line: 5,
+            column: 10,
+            funcVirtAddr: '5',
+            offset: '7',
+            params: 'console.log',
+            allocatedCategory: 'default-category',
+            allocatedName: 'event1',
+            node_module: 'default-category',
+          },
+        }),
+      ]);
+    });
+  });
+
+  describe('setting event category', () => {
+    it.each([
+      {
+        nodeModuleName: 'react-native',
+        expectedCategory: 'react-native-internals',
+      },
+      { nodeModuleName: 'react', expectedCategory: 'react-native-internals' },
+      { nodeModuleName: 'metro', expectedCategory: 'react-native-internals' },
+      {
+        nodeModuleName: 'other-module',
+        expectedCategory: 'other_node_modules',
+      },
+    ])(
+      'should correctly improve categories for node modules',
+      async ({ nodeModuleName, expectedCategory }) => {
+        ((SourceMapConsumer as unknown) as jest.Mock).mockImplementation(
+          () => ({
+            originalPositionFor: jest.fn().mockReturnValue({
+              source: `/workdir/node_modules/${nodeModuleName}/index.js`,
+              line: 1,
+              column: 10,
+              name: 'console.log',
+            }),
+            destroy: jest.fn(),
+          })
+        );
+
+        const enhancedEvents = await applySourceMapsToEvents(
+          mockSourceMap,
+          defaultEvents,
+          undefined
+        );
+
+        expect(enhancedEvents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              cat: expectedCategory,
+            }),
+          ])
+        );
+      }
+    );
+
+    it('should default to the source as the category', async () => {
+      ((SourceMapConsumer as unknown) as jest.Mock).mockImplementation(() => ({
+        originalPositionFor: jest.fn().mockReturnValue({
+          source: `asdfasd.js`,
+          line: 1,
+          column: 10,
+          name: 'console.log',
+        }),
+        destroy: jest.fn(),
+      }));
+
+      const enhancedEvents = await applySourceMapsToEvents(
+        mockSourceMap,
+        defaultEvents,
+        undefined
+      );
+
+      expect(enhancedEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            cat: 'default-category',
+          }),
+        ])
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds support for properly symbolicating production profiles taken with hermes. In production mode, hermes produces a slightly different profile format, where instead of line + column information it has `funcVirtAddr` and `offset`. As far as I can tell you can easily map this back to line and column by doing:

```ts
{
  line: 1, // always 1 for production hermes builds for now according to metro
  column: funcVirtAddr + offset + 1,
}
```

References:

* [metro-symbolicate](https://github.com/facebook/metro/blob/139f58c1eeb7b61318f6307d5be650e5484ea1c5/packages/metro-symbolicate/src/Symbolication.js#L301)
* [sentry-react-native](https://github.com/getsentry/sentry-react-native/blob/3c68fc5302bca0b1fa25fe3ade9b35b8ef89a3d5/src/js/profiling/convertHermesProfile.ts#L199)

Profiles taken with [react-native-release-profiler](https://github.com/margelo/react-native-release-profiler). An example profile + sourcemap can be found [here](https://drive.google.com/drive/folders/11-UGiXxn9cxvGXk6zioXtIAJ0e-amqQ7?usp=drive_link).

## Demo

Speedscope now has first class support for both the raw and transformed hermes profile formats, it was used for the comparisons:

Before:

<img width="1122" alt="Screenshot 2024-01-09 at 6 52 58 PM" src="https://github.com/react-native-community/hermes-profile-transformer/assets/9957046/34e56550-497d-40a6-aba6-16a1000fcaf4">

After:

<img width="1123" alt="Screenshot 2024-01-09 at 6 53 37 PM" src="https://github.com/react-native-community/hermes-profile-transformer/assets/9957046/14364f6c-4fe4-4706-aed0-9930bddae907">